### PR TITLE
[POC][WIP] Inject via a Bundler::Plugin.hook

### DIFF
--- a/lib/bundler/inject.rb
+++ b/lib/bundler/inject.rb
@@ -1,4 +1,65 @@
 require "bundler/inject/version"
-require "bundler/inject/dsl_patch"
 
-Bundler::Dsl.prepend(Bundler::Inject::DslPatch)
+module Bundler
+  module Inject
+    def inject!(dependencies)
+      # get a new Bundler::Dsl instance
+      builder = Bundler::Dsl.new
+
+      # Set the dependencies to the dependencies from the existing definition
+      builder.dependencies = dependencies
+
+      # Set the rest of the instance variables from Bundler.definition
+      #
+      # Based on Ruby's pass-by-reference design, we should be fine mutating
+      # these in the new Builder, and it should be reflected in the
+      # Bundler.definition in the end... hopefully...
+      #
+      # TODO:  Specs so we test this across bundler versions!
+      #
+      # (best we can do with the limited flexibility of Bundler::Plugin)
+      sources         = Bundler.definition.send(:sources)
+      gemfiles        = Bundler.definition.gemfiles
+      ruby_version    = Bundler.definition.send(:ruby_version)
+      optional_groups = Bundler.definition.instance_variable_get(:@optional_groups)
+
+      builder.instance_variable_set(:@sources,         sources)
+      builder.instance_variable_set(:@gemfiles,        gemfiles)
+      builder.instance_variable_set(:@ruby_version,    ruby_version)
+      builder.instance_variable_set(:@optional_groups, optional_groups)
+
+      # Load the global and local bundler.d dirs
+      load_bundler_d(builder, global_bundler_d)
+      load_bundler_d(builder, local_bundler_d)
+    end
+    module_function :inject!
+
+    def load_bundler_d(builder, dir)
+      Dir.glob(File.join(dir, '*.rb')).sort.each do |f|
+        puts "Injecting #{f}..."
+        builder.eval_gemfile(f, nil)
+      end
+    end
+    module_function :load_bundler_d
+    private_class_method :load_bundler_d
+
+    def global_bundler_d
+      File.join(Dir.home, ".bundler.d")
+    end
+    module_function :global_bundler_d
+    private_class_method :global_bundler_d
+
+    def local_bundler_d
+      File.join(File.dirname(ENV["BUNDLE_GEMFILE"]), "bundler.d")
+    end
+    module_function :local_bundler_d
+    private_class_method :local_bundler_d
+  end
+end
+
+Bundler::Plugin.add_hook('before-install-all') do |dependencies|
+  require "bundler/inject/dsl_patch"
+
+  Bundler::Dsl.prepend(Bundler::Inject::DslPatch)
+  Bundler::Inject.inject! dependencies
+end

--- a/lib/bundler/inject/dsl_patch.rb
+++ b/lib/bundler/inject/dsl_patch.rb
@@ -20,22 +20,6 @@ module Bundler
           warn "** override_gem: #{name}, #{args.inspect}, caller: #{calling_file}" unless ENV["RAILS_ENV"] == "production"
         end
       end
-
-      def eval_gemfile(gemfile, contents = nil, nested = false)
-        super(gemfile, contents)
-        return if nested
-        load_bundler_d(File.join(Dir.home, ".bundler.d"))
-        load_bundler_d(File.join(File.dirname(gemfile), "bundler.d"))
-      end
-
-      private
-
-      def load_bundler_d(dir)
-        Dir.glob(File.join(dir, '*.rb')).sort.each do |f|
-          puts "Injecting #{f}..."
-          eval_gemfile(f, nil, true)
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
NOTE:  Does not work!  Read below for details!

What this does
--------------

This changes a few things:

First, we use the documented for adding a hook:

```ruby
Bundler::Plugin.add_hook('before-install-all')
```

from the `bundler` docs: https://bundler.io/v2.0/guides/bundler_plugins.html

Second, because of the first, this means that we have to update how we load the `DslPatch`, since the `before-install-all` is triggered after the second pass of `eval_gemfile` of the `Gemfile` (first being to install plugins):

https://github.com/bundler/bundler/blob/d44d803357506895555ff97f73e60d593820a0de/lib/bundler/installer.rb#L24

(<= v1.16.x)

https://github.com/bundler/bundler/blob/c793c38a55559677573d28d4bfadd811e8508b48/lib/bundler/installer.rb#L24

This means that we need to do our own `eval_gemfile` anyway, so we rebuild a `Bundler::Dsl.builder` based off the `Bundler.definition`, and then run `eval_gemfile` on that to update the variables tied to the `Bundler.definition` (updating sources, dependencies, etc. as needed).


Why it doesn't work
-------------------

Unfortunately, this hook only runs on install, so whenever a `bundle exec ...` or `bundler/setup` is called, we don't include the `eval_gemfile` of anything in the `bundler.d` dirs.

This does `bundle install` and `bundle update` every time, so it is a decent start, but probably needs to be re-worked to use a different method.


Possible alternative:  Using a "source plugin hack"
---------------------------------------------------

The other option for plugins is "source plugins", which inject a new `Bundler::Source::*` into `bundler`'s repertoire.  This should get triggered every time when a `bundle exec` triggered as well, and we would just have to do something like the following:

**Gemfile**

```ruby
plugin 'bundler-inject' # ...
gem 'bundler-inject', :type => :bundler_inject, :require => :false
```

And then the source just creates a dummy dependecy when installing during the real pass, but can also activate the `Bundler::Inject` code as well when the source type code is loaded.

At least in theory, it should work...